### PR TITLE
optimize crypt speed by inlining

### DIFF
--- a/sm4/sm4.go
+++ b/sm4/sm4.go
@@ -149,9 +149,9 @@ func cryptBlock(subkeys []uint32, b []uint32, r []byte, dst, src []byte, decrypt
 	permuteInitialBlock(b, src)
 	for i := 0; i < 32; i++ {
 		if decrypt {
-			tm = feistel1(b[0], b[1], b[2], b[3], subkeys[31-i])
+			tm = b[0] ^ l1(p(b[1]^b[2]^b[3]^subkeys[31-i]))
 		} else {
-			tm = feistel1(b[0], b[1], b[2], b[3], subkeys[i])
+			tm = b[0] ^ l1(p(b[1]^b[2]^b[3]^subkeys[i]))
 		}
 		b[0], b[1], b[2], b[3] = b[1], b[2], b[3], tm
 	}


### PR DESCRIPTION
I think you guys need to optimize the core part of SM4 by inlining, such as feistel, sbox, shifting.

function calls themselves consumes the major portion of CPU usage, according to my profiling.  

by eliminating function calls will definitely improve speed, expecting 4x speed up if we optimized good enough.

