### PR TITLE
Support SM2WithSM3 Verify and Sign

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,23 @@
+# Note
+ This is fork of https://github.com/tjfoc/gmsm
+
+
+# Changed
+
+* Compatiable for standards SM2WithSM3 
+    * Add userID
+    * Add Z 
+    * Changed Sign and Verify for SM2
+* Verified the USBKey GM signature
+
+# TODO
+
+* Remove debug code
+* Remove redundant/dumplicated code 
+* userID as parameters
+* Prepare Pull Request
+
+# Orignal Readme
 
 GM SM2/3/4 library based on Golang
 

--- a/sm2/sm2_test.go
+++ b/sm2/sm2_test.go
@@ -12,7 +12,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-
 package sm2
 
 import (
@@ -85,7 +84,8 @@ func TestSm2(t *testing.T) {
 		fmt.Printf("Verify error\n")
 	} else {
 		fmt.Printf("Verify ok\n")
-	}
+	} 
+
 	ok = pubKey.Verify(msg, signdata) // 公钥验证
 	if ok != true {
 		fmt.Printf("Verify error\n")


### PR DESCRIPTION
The current version sign/verify use SHA512 as digest, however when use get the sign from usb , it can not work. So we add the SM2WithSM3 into codes.
The modified is only for our current projects, there are to-does  and code quality improvements.
The readme.md can be ignored, and sm2_test.go as well for format diference.