### PR TITLE
fix bug

### DIFF
--- a/sm2/sm2.go
+++ b/sm2/sm2.go
@@ -502,6 +502,7 @@ func Decompress(a []byte) *PublicKey {
 	var aa, xx, xx3 sm2P256FieldElement
 
 	x := new(big.Int).SetBytes(a[1:])
+	initP256Sm2()
 	curve := sm2P256
 	sm2P256FromBig(&xx, x)
 	sm2P256Square(&xx3, &xx)       // x3 = x ^ 2


### PR DESCRIPTION
修改了bug，需要对曲线进行初始化，否则执行下面的语句会出现如下错误：
```
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
```