### PR TITLE
bounds check elimation in main loop of encryption

### DIFF
--- a/sm4/sm4.go
+++ b/sm4/sm4.go
@@ -184,7 +184,6 @@ func permuteFinalBlock(b []byte, block []uint32) {
 
 //修改后的加密核心函数
 func cryptBlock(subkeys []uint32, b []uint32, r []byte, dst, src []byte, decrypt bool) {
-	var x uint32
 	permuteInitialBlock(b, src)
 
 	// bounds check elimination in major encryption loop
@@ -193,7 +192,7 @@ func cryptBlock(subkeys []uint32, b []uint32, r []byte, dst, src []byte, decrypt
 	if decrypt {
 		for i := 0; i < 8; i++ {
 			s := subkeys[31-4*i-3 : 31-4*i-3+4]
-			x = b[1] ^ b[2] ^ b[3] ^ s[3]
+			x := b[1] ^ b[2] ^ b[3] ^ s[3]
 			b[0] = b[0] ^ sbox0[x&0xff] ^ sbox1[(x>>8)&0xff] ^ sbox2[(x>>16)&0xff] ^ sbox3[(x>>24)&0xff]
 			x = b[0] ^ b[2] ^ b[3] ^ s[2]
 			b[1] = b[1] ^ sbox0[x&0xff] ^ sbox1[(x>>8)&0xff] ^ sbox2[(x>>16)&0xff] ^ sbox3[(x>>24)&0xff]
@@ -205,7 +204,7 @@ func cryptBlock(subkeys []uint32, b []uint32, r []byte, dst, src []byte, decrypt
 	} else {
 		for i := 0; i < 8; i++ {
 			s := subkeys[4*i : 4*i+4]
-			x = b[1] ^ b[2] ^ b[3] ^ s[0]
+			x := b[1] ^ b[2] ^ b[3] ^ s[0]
 			b[0] = b[0] ^ sbox0[x&0xff] ^ sbox1[(x>>8)&0xff] ^ sbox2[(x>>16)&0xff] ^ sbox3[(x>>24)&0xff]
 			x = b[0] ^ b[2] ^ b[3] ^ s[1]
 			b[1] = b[1] ^ sbox0[x&0xff] ^ sbox1[(x>>8)&0xff] ^ sbox2[(x>>16)&0xff] ^ sbox3[(x>>24)&0xff]

--- a/sm4/sm4.go
+++ b/sm4/sm4.go
@@ -186,26 +186,32 @@ func permuteFinalBlock(b []byte, block []uint32) {
 func cryptBlock(subkeys []uint32, b []uint32, r []byte, dst, src []byte, decrypt bool) {
 	var x uint32
 	permuteInitialBlock(b, src)
+
+	// bounds check elimination in major encryption loop
+	// https://go101.org/article/bounds-check-elimination.html
+	_ = b[3]
 	if decrypt {
 		for i := 0; i < 8; i++ {
-			x = b[1] ^ b[2] ^ b[3] ^ subkeys[31-4*i]
+			s := subkeys[31-4*i-3 : 31-4*i-3+4]
+			x = b[1] ^ b[2] ^ b[3] ^ s[3]
 			b[0] = b[0] ^ sbox0[x&0xff] ^ sbox1[(x>>8)&0xff] ^ sbox2[(x>>16)&0xff] ^ sbox3[(x>>24)&0xff]
-			x = b[0] ^ b[2] ^ b[3] ^ subkeys[31-4*i-1]
+			x = b[0] ^ b[2] ^ b[3] ^ s[2]
 			b[1] = b[1] ^ sbox0[x&0xff] ^ sbox1[(x>>8)&0xff] ^ sbox2[(x>>16)&0xff] ^ sbox3[(x>>24)&0xff]
-			x = b[0] ^ b[1] ^ b[3] ^ subkeys[31-4*i-2]
+			x = b[0] ^ b[1] ^ b[3] ^ s[1]
 			b[2] = b[2] ^ sbox0[x&0xff] ^ sbox1[(x>>8)&0xff] ^ sbox2[(x>>16)&0xff] ^ sbox3[(x>>24)&0xff]
-			x = b[1] ^ b[2] ^ b[0] ^ subkeys[31-4*i-3]
+			x = b[1] ^ b[2] ^ b[0] ^ s[0]
 			b[3] = b[3] ^ sbox0[x&0xff] ^ sbox1[(x>>8)&0xff] ^ sbox2[(x>>16)&0xff] ^ sbox3[(x>>24)&0xff]
 		}
 	} else {
 		for i := 0; i < 8; i++ {
-			x = b[1] ^ b[2] ^ b[3] ^ subkeys[4*i]
+			s := subkeys[4*i : 4*i+4]
+			x = b[1] ^ b[2] ^ b[3] ^ s[0]
 			b[0] = b[0] ^ sbox0[x&0xff] ^ sbox1[(x>>8)&0xff] ^ sbox2[(x>>16)&0xff] ^ sbox3[(x>>24)&0xff]
-			x = b[0] ^ b[2] ^ b[3] ^ subkeys[4*i+1]
+			x = b[0] ^ b[2] ^ b[3] ^ s[1]
 			b[1] = b[1] ^ sbox0[x&0xff] ^ sbox1[(x>>8)&0xff] ^ sbox2[(x>>16)&0xff] ^ sbox3[(x>>24)&0xff]
-			x = b[0] ^ b[1] ^ b[3] ^ subkeys[4*i+2]
+			x = b[0] ^ b[1] ^ b[3] ^ s[2]
 			b[2] = b[2] ^ sbox0[x&0xff] ^ sbox1[(x>>8)&0xff] ^ sbox2[(x>>16)&0xff] ^ sbox3[(x>>24)&0xff]
-			x = b[1] ^ b[2] ^ b[0] ^ subkeys[4*i+3]
+			x = b[1] ^ b[2] ^ b[0] ^ s[3]
 			b[3] = b[3] ^ sbox0[x&0xff] ^ sbox1[(x>>8)&0xff] ^ sbox2[(x>>16)&0xff] ^ sbox3[(x>>24)&0xff]
 		}
 	}

--- a/sm4/sm4_test.go
+++ b/sm4/sm4_test.go
@@ -44,7 +44,7 @@ func TestSM4(t *testing.T) {
 	c.Decrypt(d1, d0)
 	fmt.Printf("d1 = %x\n", d1)
 	if sa := testCompare(data, d1); sa != true {
-		fmt.Printf("Error data!")
+		t.Fatal("Error data!")
 	}
 }
 


### PR DESCRIPTION
Before
```
$ go build -gcflags="-d=ssa/check_bce/debug=1"  sm4.go
# command-line-arguments
./sm4.go:171:8: Found IsInBounds
./sm4.go:171:23: Found IsInBounds
./sm4.go:171:52: Found IsInBounds
./sm4.go:172:17: Found IsInBounds
./sm4.go:172:47: Found IsInBounds
./sm4.go:178:10: Found IsInBounds
./sm4.go:178:23: Found IsInBounds
./sm4.go:179:12: Found IsInBounds
./sm4.go:180:12: Found IsInBounds
./sm4.go:181:12: Found IsInBounds
./sm4.go:191:9: Found IsInBounds
./sm4.go:191:16: Found IsInBounds
./sm4.go:191:23: Found IsInBounds
./sm4.go:191:36: Found IsInBounds
./sm4.go:193:36: Found IsInBounds
./sm4.go:195:36: Found IsInBounds
./sm4.go:197:36: Found IsInBounds
./sm4.go:202:9: Found IsInBounds
./sm4.go:202:16: Found IsInBounds
./sm4.go:202:23: Found IsInBounds
./sm4.go:202:36: Found IsInBounds
./sm4.go:204:36: Found IsInBounds
./sm4.go:206:36: Found IsInBounds
./sm4.go:208:36: Found IsInBounds
./sm4.go:212:28: Found IsInBounds
./sm4.go:212:34: Found IsInBounds
./sm4.go:226:14: Found IsInBounds
```

After
```
$ go build -gcflags="-d=ssa/check_bce/debug=1"  sm4.go
# command-line-arguments
./sm4.go:171:8: Found IsInBounds
./sm4.go:171:23: Found IsInBounds
./sm4.go:171:52: Found IsInBounds
./sm4.go:172:17: Found IsInBounds
./sm4.go:172:47: Found IsInBounds
./sm4.go:178:10: Found IsInBounds
./sm4.go:178:23: Found IsInBounds
./sm4.go:179:12: Found IsInBounds
./sm4.go:180:12: Found IsInBounds
./sm4.go:181:12: Found IsInBounds
./sm4.go:192:7: Found IsInBounds
./sm4.go:195:16: Found IsSliceInBounds
./sm4.go:207:16: Found IsSliceInBounds
./sm4.go:232:14: Found IsInBounds
```


benchmark via kcp-go shows that we get 6~10% performance gain in this improvement
Before:
```
$ go test -cpuprofile=cpu.out -run=^$ -bench SM
beginning tests, encryption:salsa20, fec:10/3
goos: darwin
goarch: amd64
pkg: github.com/xtaci/kcp-go
BenchmarkSM4-4   	   50000	     33991 ns/op	  88.26 MB/s	       0 B/op	       0 allocs/op
PASS
ok  	github.com/xtaci/kcp-go	2.287s
```
After
```
$ go test -cpuprofile=cpu.out -run=^$ -bench SM
beginning tests, encryption:salsa20, fec:10/3
goos: darwin
goarch: amd64
pkg: github.com/xtaci/kcp-go
BenchmarkSM4-4   	   50000	     31625 ns/op	  94.86 MB/s	       0 B/op	       0 allocs/op
PASS
ok  	github.com/xtaci/kcp-go	2.222s
```
