### PR TITLE
Fixed: According to the GB/T 32918.2-2016 (Page 3, 6.1), when r+k=n, …

### DIFF
--- a/sm2/sm2.go
+++ b/sm2/sm2.go
@@ -220,7 +220,7 @@ func Sign(priv *PrivateKey, hash []byte) (r, s *big.Int, err error) {
 			if r.Sign() != 0 {
 				break
 			}
-			if t := new(big.Int).Add(r, k); t.Cmp(N) == 0 {
+			if t := new(big.Int).Add(r, k); t.Cmp(N) != 0 {
 				break
 			}
 		}
@@ -294,7 +294,7 @@ func Sm2Sign(priv *PrivateKey, msg, uid []byte) (r, s *big.Int, err error) {
 			if r.Sign() != 0 {
 				break
 			}
-			if t := new(big.Int).Add(r, k); t.Cmp(N) == 0 {
+			if t := new(big.Int).Add(r, k); t.Cmp(N) != 0 {
 				break
 			}
 		}


### PR DESCRIPTION
Fixed: According to the GB/T 32918.2-2016 (Page 3, 6.1), when r+k=n, it should return to Step A3.
@tjfoc 