### PR TITLE
accept nil uid when calling sm2 sign/verify

### DIFF
--- a/sm2/pkcs7.go
+++ b/sm2/pkcs7.go
@@ -141,6 +141,7 @@ func ParsePKCS7(data []byte) (p7 *PKCS7, err error) {
 	// fmt.Printf("--> Content Type: %s", info.ContentType)
 	switch {
 	case info.ContentType.Equal(oidSignedData):
+		return parseSignedData(info.Content.Bytes)
 	case info.ContentType.Equal(oidSMSignedData):
 		return parseSignedData(info.Content.Bytes)
 	case info.ContentType.Equal(oidEnvelopedData):

--- a/sm2/sm2.go
+++ b/sm2/sm2.go
@@ -352,9 +352,6 @@ func msgHash(za, msg []byte) (*big.Int, error) {
 
 // ZA = H256(ENTLA || IDA || a || b || xG || yG || xA || yA)
 func ZA(pub *PublicKey, uid []byte) ([]byte, error) {
-	if len(uid) <= 0 {
-		uid = default_uid
-	}
 	za := sm3.New()
 	uidLen := len(uid)
 	if uidLen >= 8192 {
@@ -363,7 +360,9 @@ func ZA(pub *PublicKey, uid []byte) ([]byte, error) {
 	Entla := uint16(8 * uidLen)
 	za.Write([]byte{byte((Entla >> 8) & 0xFF)})
 	za.Write([]byte{byte(Entla & 0xFF)})
-	za.Write(uid)
+	if uidLen > 0 {
+		za.Write(uid)
+	}
 	za.Write(sm2P256ToBig(&sm2P256.a).Bytes())
 	za.Write(sm2P256.B.Bytes())
 	za.Write(sm2P256.Gx.Bytes())


### PR DESCRIPTION
国密SM2签名验签时，允许空的uid