### PR TITLE
fixed: check if the block is nil to avoid panic.

### DIFF
--- a/sm4/sm4.go
+++ b/sm4/sm4.go
@@ -246,6 +246,9 @@ func DecryptBlock(key SM4Key, dst, src []byte) {
 
 func ReadKeyFromMem(data []byte, pwd []byte) (SM4Key, error) {
 	block, _ := pem.Decode(data)
+	if block == nil {
+		return nil, errors.New("SM4: pem decode failed")
+	}
 	if x509.IsEncryptedPEMBlock(block) {
 		if block.Type != "SM4 ENCRYPTED KEY" {
 			return nil, errors.New("SM4: unknown type")


### PR DESCRIPTION
If the data is not in PEM format, pem.Decode will fail and the block will be nil, which will cause an error with x509.IsEncryptedPEMBlock.