### PR TITLE
修正生成密钥逻辑

### DIFF
--- a/sm2/sm2.go
+++ b/sm2/sm2.go
@@ -104,6 +104,7 @@ func (pub *PublicKey) Encrypt(data []byte) ([]byte, error) {
 }
 
 var one = new(big.Int).SetInt64(1)
+var two = new(big.Int).SetInt64(2)
 
 func intToBytes(x int) []byte {
 	var buf = make([]byte, 4)
@@ -146,7 +147,7 @@ func randFieldElement(c elliptic.Curve, rand io.Reader) (k *big.Int, err error) 
 		return
 	}
 	k = new(big.Int).SetBytes(b)
-	n := new(big.Int).Sub(params.N, one)
+	n := new(big.Int).Sub(params.N, two)
 	k.Mod(k, n)
 	k.Add(k, one)
 	return


### PR DESCRIPTION
GB/T 32918.1-2016  小节6.1 要求生成密钥随机数 d∈[1, n-2]，但原代吗中是 k = rand%(N-1)+1，这个值的范围是[1, N-1]。
修改为 k = rand%(N-2)+1