### PR TITLE
调整了SM2私钥解密接口参数

### DIFF
--- a/sm2/sm2.go
+++ b/sm2/sm2.go
@@ -90,7 +90,7 @@ func (priv *PrivateKey) Sign(rand io.Reader, msg []byte, opts crypto.SignerOpts)
 	return asn1.Marshal(sm2Signature{r, s})
 }
 
-func (priv *PrivateKey) Decrypt(data []byte) ([]byte, error) {
+func (priv *PrivateKey) Decrypt(rand io.Reader, data []byte, opts crypto.DecrypterOpts) ([]byte, error) {
 	return DecryptAsn1(priv, data)
 }
 


### PR DESCRIPTION
调整了参数使其能够兼容golang 中的非对称密钥解密接口。


在使用过程中我很多时候都需要  类型检查一下 是不是SM2私钥，然后特殊处理，这导致在很多go标准的接口都无法使用，需要修改和调整代码，非常不便，建议兼容 golang 中的 crypto.Decrypter 接口。

确实`rand io.Reader`和`opts crypto.DecrypterOpts`是不需要的，如果需要使用`Decrypt(data []byte) ([]byte, error)`，我觉得还是直接调用`func Decrypt(priv *PrivateKey, data []byte) ([]byte, error)`方法较好，

所以`sn2.PrivateKey`尽可能与上层兼容。