### PR TITLE
增加sm2密钥格式支持；增加sm2旧加密模式支持

### DIFF
--- a/gmtls/gm_key_agreement.go
+++ b/gmtls/gm_key_agreement.go
@@ -429,7 +429,7 @@ func (ka *eccKeyAgreementGM) generateClientKeyExchange(config *Config, clientHel
 	}
 	pubKey := ka.encipherCert.PublicKey.(*ecdsa.PublicKey)
 	sm2PubKey := &sm2.PublicKey{Curve: pubKey.Curve, X: pubKey.X, Y: pubKey.Y}
-	encrypted, err := sm2.Encrypt(sm2PubKey, preMasterSecret, config.rand())
+	encrypted, err := sm2.Encrypt(sm2PubKey, preMasterSecret, config.rand(),0)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/sm2/sm2.go
+++ b/sm2/sm2.go
@@ -32,6 +32,8 @@ import (
 
 var (
 	default_uid = []byte{0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37, 0x38, 0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37, 0x38}
+	C1C3C2=0
+	C1C2C3=1
 )
 
 type PublicKey struct {
@@ -242,7 +244,7 @@ func Verify(pub *PublicKey, hash []byte, r, s *big.Int) bool {
  *  hash
  *  CipherText
  */
-func Encrypt(pub *PublicKey, data []byte, random io.Reader) ([]byte, error) {
+func Encrypt(pub *PublicKey, data []byte, random io.Reader,mode int) ([]byte, error) {
 	length := len(data)
 	for {
 		c := []byte{}
@@ -285,39 +287,50 @@ func Encrypt(pub *PublicKey, data []byte, random io.Reader) ([]byte, error) {
 		for i := 0; i < length; i++ {
 			c[96+i] ^= data[i]
 		}
-		return append([]byte{0x04}, c...), nil
+		switch mode{
+	
+		case C1C3C2:
+			return append([]byte{0x04}, c...), nil
+		case C1C2C3:
+			c1 := make([]byte, 64)
+			c2 := make([]byte, len(c) - 96)
+			c3 := make([]byte, 32)
+			copy(c1, c[:64])//x1,y1
+			copy(c3, c[64:96])//hash
+			copy(c2, c[96:])//密文
+			ciphertext := []byte{}
+			ciphertext = append(ciphertext, c1...)
+			ciphertext = append(ciphertext, c2...)
+			ciphertext = append(ciphertext, c3...)
+			return append([]byte{0x04}, ciphertext...), nil
+    	default:
+			return append([]byte{0x04}, c...), nil
 	}
 }
-
-/*
- * sm2密文结构如下:
- *  x
- *  y
- *  CipherText
- *  hash
- */
-func EncryptWithOldModel(pub *PublicKey, data []byte, random io.Reader) ([]byte, error) {
-	ciphertext, err := Encrypt(pub, data, random);
-	if err != nil {
-		return ciphertext, err
-	}
-	ciphertext = ciphertext[1:]
-	c1 := make([]byte, 64)
-	c2 := make([]byte, len(ciphertext) - 96)
-	c3 := make([]byte, 32)
-	copy(c1, ciphertext[:64])//x1,y1
-	copy(c3, ciphertext[64:96])//hash
-	copy(c2, ciphertext[96:])//密文
-	c := []byte{}
-	c = append(c, c1...)
-	c = append(c, c2...)
-	c = append(c, c3...)
-
-	return append([]byte{0x04}, c...), nil
 }
 
-func Decrypt(priv *PrivateKey, data []byte) ([]byte, error) {
-	data = data[1:]
+
+
+func Decrypt(priv *PrivateKey, data []byte,mode int) ([]byte, error) {
+	switch mode {
+	case C1C3C2:
+		data = data[1:]
+	case  C1C2C3:
+		data = data[1:]
+		c1 := make([]byte, 64)
+		c2 := make([]byte, len(data) - 96)
+		c3 := make([]byte, 32)
+		copy(c1, data[:64])//x1,y1
+		copy(c2, data[64:len(data) - 32])//密文
+		copy(c3, data[len(data) - 32:])//hash
+		c := []byte{}
+		c = append(c, c1...)
+		c = append(c, c3...)
+		c = append(c, c2...)
+		data = c
+	default:
+		data = data[1:]
+	}
 	length := len(data) - 96
 	curve := priv.Curve
 	x := new(big.Int).SetBytes(data[:32])
@@ -349,22 +362,6 @@ func Decrypt(priv *PrivateKey, data []byte) ([]byte, error) {
 	return c, nil
 }
 
-func DecryptWithOldModel(priv *PrivateKey, data []byte) ([]byte, error) {
-	data = data[1:]
-	c1 := make([]byte, 64)
-	c2 := make([]byte, len(data) - 96)
-	c3 := make([]byte, 32)
-
-	copy(c1, data[:64])//x1,y1
-	copy(c2, data[64:len(data) - 32])//密文
-	copy(c3, data[len(data) - 32:])//hash
-	c := []byte{}
-	c = append(c, c1...)
-	c = append(c, c3...)
-	c = append(c, c2...)
-	data = append([]byte{0x04}, c...)
-	return Decrypt(priv, data)
-}
 
 
 // keyExchange 为SM2密钥交换算法的第二部和第三步复用部分，协商的双方均调用此函数计算共同的字节串
@@ -482,7 +479,7 @@ func zeroByteSlice() []byte {
 sm2加密，返回asn.1编码格式的密文内容
 */
 func EncryptAsn1(pub *PublicKey, data []byte, rand io.Reader) ([]byte, error) {
-	cipher, err := Encrypt(pub, data, rand)
+	cipher, err := Encrypt(pub, data, rand,C1C3C2)
 	if err != nil {
 		return nil, err
 	}
@@ -497,7 +494,7 @@ func DecryptAsn1(pub *PrivateKey, data []byte) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	return Decrypt(pub, cipher)
+	return Decrypt(pub, cipher,C1C3C2)
 }
 
 /*
@@ -673,5 +670,5 @@ func getLastBit(a *big.Int) uint {
 
 // crypto.Decrypter
 func (priv *PrivateKey) Decrypt(_ io.Reader, msg []byte, _ crypto.DecrypterOpts) (plaintext []byte, err error) {
-	return Decrypt(priv, msg)
+	return Decrypt(priv, msg,C1C3C2)
 }

--- a/sm2/sm2_test.go
+++ b/sm2/sm2_test.go
@@ -45,7 +45,17 @@ func TestSm2(t *testing.T) {
 		fmt.Printf("Error: failed to decrypt: %v\n", err)
 	}
 	fmt.Printf("clear text = %s\n", d1)
-
+	d2, err :=Encrypt(pub,msg, rand.Reader,C1C2C3)
+	if err != nil {
+		fmt.Printf("Error: failed to encrypt %s: %v\n", msg, err)
+		return
+	}
+	// fmt.Printf("Cipher text = %v\n", d0)
+	d3, err := Decrypt(priv,d2,C1C2C3)
+	if err != nil {
+		fmt.Printf("Error: failed to decrypt: %v\n", err)
+	}
+	fmt.Printf("clear text = %s\n", d3)
 	msg, _ = ioutil.ReadFile("ifile")             // 从文件读取数据
 	sign, err := priv.Sign(rand.Reader, msg, nil) // 签名
 	if err != nil {

--- a/x509/utils.go
+++ b/x509/utils.go
@@ -3,7 +3,6 @@ package x509
 import (
 	"bytes"
 	"crypto"
-	"crypto/elliptic"
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/x509"


### PR DESCRIPTION
1. 形如以下格式的sm2密钥有的仍在使用，新增代码对其进行了支持
私钥：4d5128637b7ec2b113954ff0b10609ce9833b2de88cc89e7275cdfdd7064f5ab
公钥：04fb6a5b1fa33c1c9d86ec49ab35adfd65bab9937f6c84253453556967758f4d80c4c0e17bb28c221ded6825dadf84ae4672718d8010c8a98eef016c3db83b6fae
私钥：
-----BEGIN EC PRIVATE KEY-----
MHcCAQEEIE1RKGN7fsKxE5VP8LEGCc6YM7LeiMyJ5ydc391wZPWroAoGCCqBHM9V
AYItoUQDQgAE+2pbH6M8HJ2G7EmrNa39Zbq5k39shCU0U1VpZ3WPTYDEwOF7sowi
He1oJdrfhK5GcnGNgBDIqY7vAWw9uDtvrg==
-----END EC PRIVATE KEY-----
2. sm2旧加密模式C1C2C3仍有很多地方在用，新增代码对其进行了支持