### PR TITLE
go 大于v2版本模块引入问题。

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/tjfoc/gmsm/v2
+module github.com/XiaoTianFork/gmsm/v2
 
 go 1.14
 


### PR DESCRIPTION
在module后面添加 `v2` 后缀，合并之后需要重新release一下。