### PR TITLE
修复GMSSL服务端证书验证逻辑问题

### DIFF
--- a/gmtls/auto_handshake_server.go
+++ b/gmtls/auto_handshake_server.go
@@ -51,7 +51,7 @@ func (c *Conn) serverHandshakeAutoSwitch() error {
 		return runServerHandshakeGM(c, hs, isResume)
 	case VersionSSL30, VersionTLS10, VersionTLS11, VersionTLS12:
 		// SSL v3.0 - TLS 1.3
-		// 构造 国密SSL握手 状态上下文
+		// 构造 TLS 状态上下文
 		hs := &serverHandshakeState{
 			c:           c,
 			clientHello: clientHello,
@@ -61,7 +61,7 @@ func (c *Conn) serverHandshakeAutoSwitch() error {
 		if err != nil {
 			return err
 		}
-		// 运行 GMSSL 握手流程
+		// 运行 TLS 握手流程
 		return runServerHandshake(c, hs, isResume)
 	default:
 		_ = c.sendAlert(alertProtocolVersion)

--- a/gmtls/gm_handshake_client.go
+++ b/gmtls/gm_handshake_client.go
@@ -10,7 +10,6 @@ import (
 	"bytes"
 	"crypto"
 	"crypto/ecdsa"
-	"crypto/rsa"
 	"crypto/subtle"
 	"errors"
 	"fmt"
@@ -202,29 +201,11 @@ func (hs *clientHandshakeStateGM) doFullHandshake() error {
 				return errors.New("tls: failed to parse certificate from server: " + err.Error())
 			}
 
-			// mod by syl below
-			//if cert.SignatureAlgorithm != x509.SM2WithSM3{
-			//	c.sendAlert(alertUnsupportedCertificate)
-			//	return fmt.Errorf("tls: SignatureAlgorithm of the certificate[%d] is not supported, actual:%s, expect:SM2WITHSM3", i, cert.SignatureAlgorithm.String())
-			//}
-			//if cert.PublicKeyAlgorithm != x509.SM2 {
-			//	c.sendAlert(alertUnsupportedCertificate)
-			//	return fmt.Errorf("tls: PublicKeyAlgorithm of the certificate[%d] is not supported, actual:%s, expect:SM2", i, []string{"unkown", "RSA", "DSA", "ECDSA", "SM2"}[int(cert.PublicKeyAlgorithm)])
-			//}
-			////cert[0] is for signature while cert[1] is for encipher, refer to  GMT0024
-			////check key usage
-			//switch i {
-			//case 0:
-			//	if cert.KeyUsage == 0 || (cert.KeyUsage & (x509.KeyUsageDigitalSignature | cert.KeyUsage&x509.KeyUsageContentCommitment)) == 0{
-			//		c.sendAlert(alertInsufficientSecurity)
-			//		return fmt.Errorf("tls: the keyusage of cert[0] does not exist or is not for KeyUsageDigitalSignature/KeyUsageContentCommitment, value:%d", cert.KeyUsage)
-			//	}
-			//case 1:
-			//	if cert.KeyUsage == 0 || (cert.KeyUsage & (x509.KeyUsageDataEncipherment | x509.KeyUsageKeyEncipherment | x509.KeyUsageKeyAgreement))==0{
-			//		c.sendAlert(alertInsufficientSecurity)
-			//		return fmt.Errorf("tls: the keyusage of cert[1] does not exist or is not for KeyUsageDataEncipherment/KeyUsageKeyEncipherment/KeyUsageKeyAgreement, value:%d", cert.KeyUsage)
-			//	}
-			//}
+			pubKey, _ := cert.PublicKey.(*ecdsa.PublicKey)
+			if pubKey.Curve != sm2.P256Sm2() {
+				c.sendAlert(alertUnsupportedCertificate)
+				return fmt.Errorf("tls: pubkey type of cert is error, expect sm2.publicKey")
+			}
 
 			certs[i] = cert
 		}
@@ -244,16 +225,17 @@ func (hs *clientHandshakeStateGM) doFullHandshake() error {
 				opts.Roots.AddCert(rootca)
 			}
 			for i, cert := range certs {
-				if i == 0 {
+				// GM SSL 证书链中不含根证书 第1张为签名证书、第2张为加密证书，其他的证书都认为是根证书
+				if i == 0 || i == 1 {
+					// 只验证 签名证书  和 加密证书
+					c.verifiedChains, err = certs[i].Verify(opts)
+					if err != nil {
+						_ = c.sendAlert(alertBadCertificate)
+						return err
+					}
 					continue
 				}
 				opts.Intermediates.AddCert(cert)
-			}
-
-			c.verifiedChains, err = certs[0].Verify(opts)
-			if err != nil {
-				c.sendAlert(alertBadCertificate)
-				return err
 			}
 		}
 
@@ -265,7 +247,7 @@ func (hs *clientHandshakeStateGM) doFullHandshake() error {
 		}
 
 		switch certs[0].PublicKey.(type) {
-		case *sm2.PublicKey, *ecdsa.PublicKey, *rsa.PublicKey:
+		case *sm2.PublicKey, *ecdsa.PublicKey:
 			break
 		default:
 			c.sendAlert(alertUnsupportedCertificate)

--- a/gmtls/simple_round_trip.go
+++ b/gmtls/simple_round_trip.go
@@ -1,0 +1,68 @@
+package gmtls
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"sync"
+)
+
+// SimpleRoundTripper 简单的单次HTTP/HTTPS（国密） 连接往返器
+// 每次建立新的连接
+type SimpleRoundTripper struct {
+	lock      sync.Mutex
+	tlsConfig *Config
+}
+
+func NewSimpleRoundTripper(cfg *Config) *SimpleRoundTripper {
+	return &SimpleRoundTripper{tlsConfig: cfg}
+}
+
+func (s *SimpleRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	// 加锁保证线程安全
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	scheme := req.URL.Scheme
+	isHTTP := scheme == "http" || scheme == "https"
+	if !isHTTP {
+		return nil, fmt.Errorf("仅支持http/https协议")
+	}
+
+	// 获取主机名 和 端口
+	hostname := req.URL.Hostname()
+	port := req.URL.Port()
+	address := net.JoinHostPort(hostname, port)
+
+	var conn io.ReadWriteCloser
+	var err error
+	// 根据协议建立连接
+	if scheme == "http" {
+		// HTTP 协议建立TCP连接
+		conn, err = net.Dial("tcp", address)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		// HTTPS 协议建立TLS连接
+		conn, err = Dial("tcp", address, s.tlsConfig)
+		if err != nil {
+			return nil, err
+		}
+	}
+	defer conn.Close()
+
+	// 把请求写入连接中，发起请求
+	err = req.Write(conn)
+	if err != nil {
+		return nil, err
+	}
+	// 从连接中读取
+	response, err := http.ReadResponse(bufio.NewReader(conn), req)
+	if err != nil {
+		return nil, err
+	}
+	return response, nil
+}

--- a/gmtls/simple_round_trip_test.go
+++ b/gmtls/simple_round_trip_test.go
@@ -1,0 +1,120 @@
+package gmtls
+
+import (
+	"bytes"
+	"fmt"
+	"github.com/tjfoc/gmsm/x509"
+	"io/ioutil"
+	"net/http"
+	"testing"
+	"time"
+)
+
+var _ExpectRawContent = []byte("Hello World!")
+
+// 启动HTTP测试服务器
+func bootHttpServer(t *testing.T) {
+	serveMux := http.NewServeMux()
+	serveMux.HandleFunc("/", func(writer http.ResponseWriter, request *http.Request) {
+		_, _ = writer.Write(_ExpectRawContent)
+	})
+	fmt.Println(">> HTTP :50053 running...")
+	err := http.ListenAndServe(":50053", serveMux)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+// 启动GM HTTPS测试服务器
+func bootGMHTTPSServer(t *testing.T) {
+	sigCert, err := LoadX509KeyPair(
+		"websvr/certs/sm2_sign_cert.cer",
+		"websvr/certs/sm2_sign_key.pem")
+	if err != nil {
+
+	}
+	encCert, err := LoadX509KeyPair(
+		"websvr/certs/sm2_enc_cert.cer",
+		"websvr/certs/sm2_enc_key.pem")
+	if err != nil {
+		t.Fatal(err)
+	}
+	config := &Config{
+		GMSupport:          &GMSupport{},
+		Certificates:       []Certificate{sigCert, encCert},
+		InsecureSkipVerify: true,
+	}
+	if err != nil {
+		panic(err)
+	}
+
+	ln, err := Listen("tcp", ":50054", config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ln.Close()
+	serveMux := http.NewServeMux()
+	serveMux.HandleFunc("/", func(writer http.ResponseWriter, request *http.Request) {
+		_, _ = writer.Write(_ExpectRawContent)
+	})
+	fmt.Println(">> HTTP :50054 [GMSSL] running...")
+	err = http.Serve(ln, serveMux)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+// HTTP 客户端连接测试
+func TestSimpleRoundTripper_RoundTrip1(t *testing.T) {
+	go bootHttpServer(t)
+	//go bootGMHTTPSServer(t)
+	/*
+		HTTP 连接测试
+	*/
+	time.Sleep(time.Second)
+	httpClient := http.Client{Transport: NewSimpleRoundTripper(nil)}
+	response, err := httpClient.Get("http://localhost:50053")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer response.Body.Close()
+	raw, err := ioutil.ReadAll(response.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(raw, _ExpectRawContent) {
+		t.Fatalf(">> HTTP响应内容与期待内容不符, expect %s, actual: %s", string(_ExpectRawContent), string(raw))
+	}
+}
+
+// GM HTTPS 客户端连接测试
+func TestSimpleRoundTripper_RoundTrip2(t *testing.T) {
+	go bootGMHTTPSServer(t)
+	/*
+		GM HTTP 连接测试
+	*/
+	time.Sleep(time.Second)
+	// 信任的根证书
+	certPool := x509.NewCertPool()
+	cacert, err := ioutil.ReadFile("websvr/certs/SM2_CA.cer")
+	if err != nil {
+		t.Fatal(err)
+	}
+	certPool.AppendCertsFromPEM(cacert)
+	httpClient := http.Client{Transport: NewSimpleRoundTripper(&Config{
+		GMSupport: &GMSupport{},
+		RootCAs:   certPool,
+	})}
+	response, err := httpClient.Get("https://localhost:50054")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer response.Body.Close()
+	raw, err := ioutil.ReadAll(response.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(raw, _ExpectRawContent) {
+		t.Fatalf(">> GM HTTPS响应内容与期待内容不符, expect %s, actual: %s", string(_ExpectRawContent), string(raw))
+	}
+}

--- a/gmtls/websvr/README.md
+++ b/gmtls/websvr/README.md
@@ -102,8 +102,8 @@ fncGetSignCertKeypair := func(info *gmtls.ClientHelloInfo) (*gmtls.Certificate, 
     // 检查支持协议中是否包含GMSSL
     for _, v := range info.SupportedVersions {
         if v == gmtls.VersionGMSSL {
-        gmFlag = true
-        break
+            gmFlag = true
+            break
         }
     }
     if gmFlag {


### PR DESCRIPTION
修复了单证书SM2客户端GMSSL证书验证不正确的问题。

由于GMSSL证书都是SM2证书因此不能出现RSA证书，对于密钥检查出现了非SM2、ECDSA的证书就认为非法

客户端对于服务端的证书验证，只验证前两张证书（签名、加密）后面的如果出现证书，则认为是证书链中的证书。