### PR TITLE
Fix SimpleRoundTripper

### DIFF
--- a/gmtls/http_client_test.go
+++ b/gmtls/http_client_test.go
@@ -234,3 +234,35 @@ func createClientGMTLSConfig(keyPath string, certPath string, caPaths []string) 
 	return cfg, nil
 
 }
+
+func ExampleHTTPSClient_Insecure() {
+	certPool := x509.NewCertPool()
+
+	tlsConfig := Config{
+		GMSupport:          &GMSupport{WorkMode: ModeGMSSLOnly},
+		RootCAs:            certPool,
+		InsecureSkipVerify: true,
+	}
+	httpClient := http.Client{
+		Transport: NewSimpleRoundTripper(&tlsConfig),
+	}
+
+	urlstr := "https://sm2test.ovssl.cn"
+	response, err := httpClient.Get(urlstr)
+	if err != nil {
+		panic(err)
+	}
+	defer response.Body.Close()
+
+	if response.StatusCode != http.StatusOK {
+		panic(fmt.Errorf("unexpected response status: %v", response.Status))
+	}
+
+	_, err = ioutil.ReadAll(response.Body)
+	if err != nil {
+		panic(fmt.Errorf("read response failed: %v", err))
+	}
+
+	fmt.Println("Ok")
+	// Output: Ok
+}

--- a/go.sum
+++ b/go.sum
@@ -48,7 +48,6 @@ golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f h1:+Nyd8tzPX9R7BWHguqsrbFdRx3WQ/1ib8I44HXV5yTA=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.3 h1:cokOdA+Jmi5PJGXLlLllQSgYigAEfHXJAERHVMaCc2k=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=


### PR DESCRIPTION
- 让调用方读完 response.Body 后再自行关闭 response.Body
- 修复 https url 的默认端口